### PR TITLE
remove grunt as a hard dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt": "~0.3",
     "temporary": "~0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to the discussion in cowboy/grunt#263 it's recommended you only reference grunt in the `devDependencies`.

This helps us greatly in Yeoman as it cuts down install time quite a bit. 
