### PR TITLE
The Mocha vs mocha test failed, here is a more robust handling of the pr...

### DIFF
--- a/tasks/mocha/mocha-helper.js
+++ b/tasks/mocha/mocha-helper.js
@@ -18,7 +18,13 @@
 
     var GruntReporter = function(runner){
       // 1.4.2 moved reporters to Mocha instead of mocha
-			var reporters = window.Mocha.reporters || window.mocha.reporters;
+			var mochaInstance = window.Mocha || window.mocha;
+
+			if (!mochaInstance) {
+				throw new Error('Mocha was not found, make sure you include Mocha in your HTML spec file.');
+			}
+
+			var reporters = mochaInstance.reporters;
 
       reporters.HTML.call(this, runner);
 


### PR DESCRIPTION
Tried using grunt-mocha and ran into a problem where it failed because there was no test to see whether Mocha was defined, and so it failed. 

This fixes the problem.  I tried a try..catch solution initially, but it was pretty ugly, although I don't think this is much better.

The whitespace changes seem to have been made by my editor, but it is a bit cleaner this way.

Thanks, and hope this is helpful.

Rohan
