### PR TITLE
update chai.js to 1.4.0

### DIFF
--- a/example/test/js/chai.js
+++ b/example/test/js/chai.js
@@ -1,9 +1,14 @@
 !function (name, context, definition) {
-  if (typeof module !== 'undefined') module.exports = definition(name, context);
-  else if (typeof define === 'function' && typeof define.amd  === 'object') define(definition);
-  else context[name] = definition(name, context);
-}('chai', this, function (name, context) {
-
+  if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
+    module.exports = definition();
+  } else if (typeof define === 'function' && typeof define.amd  === 'object') {
+    define(function () {
+      return definition();
+    });
+  } else {
+    context[name] = definition();
+  }
+}('chai', this, function () {
 
   function require(p) {
     var path = require.resolve(p)
@@ -33,7 +38,7 @@
 
   require.relative = function (parent) {
     return function(p){
-      if ('.' != p[0]) return require(p);
+      if ('.' != p.charAt(0)) return require(p);
 
       var path = parent.split('/')
         , segs = p.split('/');
@@ -69,7 +74,7 @@
      * Chai version
      */
 
-    exports.version = '1.1.0';
+    exports.version = '1.4.0';
 
     /*!
      * Primary `Assertion` prototype
@@ -224,11 +229,11 @@
      */
 
     Assertion.prototype.assert = function (expr, msg, negateMsg, expected, _actual) {
-      var msg = util.getMessage(this, arguments)
-        , actual = util.getActual(this, arguments)
-        , ok = util.test(this, arguments);
+      var ok = util.test(this, arguments);
 
       if (!ok) {
+        var msg = util.getMessage(this, arguments)
+          , actual = util.getActual(this, arguments);
         throw new AssertionError({
             message: msg
           , actual: actual
@@ -320,6 +325,8 @@
        * - and
        * - have
        * - with
+       * - at
+       * - of
        *
        * @name language chains
        * @api public
@@ -327,7 +334,8 @@
 
       [ 'to', 'be', 'been'
       , 'is', 'and', 'have'
-      , 'with', 'that' ].forEach(function (chain) {
+      , 'with', 'that', 'at'
+      , 'of' ].forEach(function (chain) {
         Assertion.addProperty(chain, function () {
           return this;
         });
@@ -388,10 +396,12 @@
        * @name a
        * @alias an
        * @param {String} type
+       * @param {String} message _optional_
        * @api public
        */
 
-      function an(type) {
+      function an(type, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object')
           , klassStart = type.charAt(0).toUpperCase()
           , klass = klassStart + type.slice(1)
@@ -422,6 +432,7 @@
        * @name include
        * @alias contain
        * @param {Object|String|Number} obj
+       * @param {String} message _optional_
        * @api public
        */
 
@@ -429,7 +440,8 @@
         flag(this, 'contains', true);
       }
 
-      function include (val) {
+      function include (val, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object')
         this.assert(
             ~obj.indexOf(val)
@@ -643,13 +655,16 @@
        *     expect({ foo: 'bar' }).to.deep.equal({ foo: 'bar' });
        *
        * @name equal
+       * @alias equals
        * @alias eq
        * @alias deep.equal
        * @param {Mixed} value
+       * @param {String} message _optional_
        * @api public
        */
 
-      function assertEqual (val) {
+      function assertEqual (val, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
         if (flag(this, 'deep')) {
           return this.eql(val);
@@ -664,6 +679,7 @@
       }
 
       Assertion.addMethod('equal', assertEqual);
+      Assertion.addMethod('equals', assertEqual);
       Assertion.addMethod('eq', assertEqual);
 
       /**
@@ -676,10 +692,12 @@
        *
        * @name eql
        * @param {Mixed} value
+       * @param {String} message _optional_
        * @api public
        */
 
-      Assertion.addMethod('eql', function (obj) {
+      Assertion.addMethod('eql', function (obj, msg) {
+        if (msg) flag(this, 'message', msg);
         this.assert(
             _.eql(obj, flag(this, 'object'))
           , 'expected #{this} to deeply equal #{exp}'
@@ -707,13 +725,15 @@
        * @alias gt
        * @alias greaterThan
        * @param {Number} value
+       * @param {String} message _optional_
        * @api public
        */
 
-      function assertAbove (n) {
+      function assertAbove (n, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
         if (flag(this, 'doLength')) {
-          new Assertion(obj).to.have.property('length');
+          new Assertion(obj, msg).to.have.property('length');
           var len = obj.length;
           this.assert(
               len > n
@@ -726,7 +746,7 @@
           this.assert(
               obj > n
             , 'expected #{this} to be above ' + n
-            , 'expected #{this} to be below ' + n
+            , 'expected #{this} to be at most ' + n
           );
         }
       }
@@ -734,6 +754,53 @@
       Assertion.addMethod('above', assertAbove);
       Assertion.addMethod('gt', assertAbove);
       Assertion.addMethod('greaterThan', assertAbove);
+
+      /**
+       * ### .least(value)
+       *
+       * Asserts that the target is greater than or equal to `value`.
+       *
+       *     expect(10).to.be.at.least(10);
+       *
+       * Can also be used in conjunction with `length` to
+       * assert a minimum length. The benefit being a
+       * more informative error message than if the length
+       * was supplied directly.
+       *
+       *     expect('foo').to.have.length.of.at.least(2);
+       *     expect([ 1, 2, 3 ]).to.have.length.of.at.least(3);
+       *
+       * @name least
+       * @alias gte
+       * @param {Number} value
+       * @param {String} message _optional_
+       * @api public
+       */
+
+      function assertLeast (n, msg) {
+        if (msg) flag(this, 'message', msg);
+        var obj = flag(this, 'object');
+        if (flag(this, 'doLength')) {
+          new Assertion(obj, msg).to.have.property('length');
+          var len = obj.length;
+          this.assert(
+              len >= n
+            , 'expected #{this} to have a length at least #{exp} but got #{act}'
+            , 'expected #{this} to not have a length below #{exp}'
+            , n
+            , len
+          );
+        } else {
+          this.assert(
+              obj >= n
+            , 'expected #{this} to be at least ' + n
+            , 'expected #{this} to be below ' + n
+          );
+        }
+      }
+
+      Assertion.addMethod('least', assertLeast);
+      Assertion.addMethod('gte', assertLeast);
 
       /**
        * ### .below(value)
@@ -754,13 +821,15 @@
        * @alias lt
        * @alias lessThan
        * @param {Number} value
+       * @param {String} message _optional_
        * @api public
        */
 
-      function assertBelow (n) {
+      function assertBelow (n, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
         if (flag(this, 'doLength')) {
-          new Assertion(obj).to.have.property('length');
+          new Assertion(obj, msg).to.have.property('length');
           var len = obj.length;
           this.assert(
               len < n
@@ -773,7 +842,7 @@
           this.assert(
               obj < n
             , 'expected #{this} to be below ' + n
-            , 'expected #{this} to be above ' + n
+            , 'expected #{this} to be at least ' + n
           );
         }
       }
@@ -781,6 +850,53 @@
       Assertion.addMethod('below', assertBelow);
       Assertion.addMethod('lt', assertBelow);
       Assertion.addMethod('lessThan', assertBelow);
+
+      /**
+       * ### .most(value)
+       *
+       * Asserts that the target is less than or equal to `value`.
+       *
+       *     expect(5).to.be.at.most(5);
+       *
+       * Can also be used in conjunction with `length` to
+       * assert a maximum length. The benefit being a
+       * more informative error message than if the length
+       * was supplied directly.
+       *
+       *     expect('foo').to.have.length.of.at.most(4);
+       *     expect([ 1, 2, 3 ]).to.have.length.of.at.most(3);
+       *
+       * @name most
+       * @alias lte
+       * @param {Number} value
+       * @param {String} message _optional_
+       * @api public
+       */
+
+      function assertMost (n, msg) {
+        if (msg) flag(this, 'message', msg);
+        var obj = flag(this, 'object');
+        if (flag(this, 'doLength')) {
+          new Assertion(obj, msg).to.have.property('length');
+          var len = obj.length;
+          this.assert(
+              len <= n
+            , 'expected #{this} to have a length at most #{exp} but got #{act}'
+            , 'expected #{this} to not have a length above #{exp}'
+            , n
+            , len
+          );
+        } else {
+          this.assert(
+              obj <= n
+            , 'expected #{this} to be at most ' + n
+            , 'expected #{this} to be above ' + n
+          );
+        }
+      }
+
+      Assertion.addMethod('most', assertMost);
+      Assertion.addMethod('lte', assertMost);
 
       /**
        * ### .within(start, finish)
@@ -800,14 +916,16 @@
        * @name within
        * @param {Number} start lowerbound inclusive
        * @param {Number} finish upperbound inclusive
+       * @param {String} message _optional_
        * @api public
        */
 
-      Assertion.addMethod('within', function (start, finish) {
+      Assertion.addMethod('within', function (start, finish, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object')
           , range = start + '..' + finish;
         if (flag(this, 'doLength')) {
-          new Assertion(obj).to.have.property('length');
+          new Assertion(obj, msg).to.have.property('length');
           var len = obj.length;
           this.assert(
               len >= start && len <= finish
@@ -836,11 +954,13 @@
        *
        * @name instanceof
        * @param {Constructor} constructor
+       * @param {String} message _optional_
        * @alias instanceOf
        * @api public
        */
 
-      function assertInstanceOf (constructor) {
+      function assertInstanceOf (constructor, msg) {
+        if (msg) flag(this, 'message', msg);
         var name = _.getName(constructor);
         this.assert(
             flag(this, 'object') instanceof constructor
@@ -906,19 +1026,25 @@
        * @alias deep.property
        * @param {String} name
        * @param {Mixed} value (optional)
+       * @param {String} message _optional_
        * @returns value of property for chaining
        * @api public
        */
 
-      Assertion.addMethod('property', function (name, val) {
-        var obj = flag(this, 'object')
-          , value = flag(this, 'deep') ? _.getPathValue(name, obj) : obj[name]
-          , descriptor = flag(this, 'deep') ? 'deep property ' : 'property '
-          , negate = flag(this, 'negate');
+      Assertion.addMethod('property', function (name, val, msg) {
+        if (msg) flag(this, 'message', msg);
+
+        var descriptor = flag(this, 'deep') ? 'deep property ' : 'property '
+          , negate = flag(this, 'negate')
+          , obj = flag(this, 'object')
+          , value = flag(this, 'deep')
+            ? _.getPathValue(name, obj)
+            : obj[name];
 
         if (negate && undefined !== val) {
           if (undefined === value) {
-            throw new Error(_.inspect(obj) + ' has no ' + descriptor + _.inspect(name));
+            msg = (msg != null) ? msg + ': ' : '';
+            throw new Error(msg + _.inspect(obj) + ' has no ' + descriptor + _.inspect(name));
           }
         } else {
           this.assert(
@@ -951,10 +1077,12 @@
        * @name ownProperty
        * @alias haveOwnProperty
        * @param {String} name
+       * @param {String} message _optional_
        * @api public
        */
 
-      function assertOwnProperty (name) {
+      function assertOwnProperty (name, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
         this.assert(
             obj.hasOwnProperty(name)
@@ -988,6 +1116,7 @@
        * @name length
        * @alias lengthOf
        * @param {Number} length
+       * @param {String} message _optional_
        * @api public
        */
 
@@ -995,9 +1124,10 @@
         flag(this, 'doLength', true);
       }
 
-      function assertLength (n) {
+      function assertLength (n, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
-        new Assertion(obj).to.have.property('length');
+        new Assertion(obj, msg).to.have.property('length');
         var len = obj.length;
 
         this.assert(
@@ -1021,10 +1151,12 @@
        *
        * @name match
        * @param {RegExp} RegularExpression
+       * @param {String} message _optional_
        * @api public
        */
 
-      Assertion.addMethod('match', function (re) {
+      Assertion.addMethod('match', function (re, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
         this.assert(
             re.exec(obj)
@@ -1042,12 +1174,14 @@
        *
        * @name string
        * @param {String} string
+       * @param {String} message _optional_
        * @api public
        */
 
-      Assertion.addMethod('string', function (str) {
+      Assertion.addMethod('string', function (str, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
-        new Assertion(obj).is.a('string');
+        new Assertion(obj, msg).is.a('string');
 
         this.assert(
             ~obj.indexOf(str)
@@ -1154,28 +1288,32 @@
        * @alias throws
        * @alias Throw
        * @param {ErrorConstructor} constructor
+       * @param {String|RegExp} expected error message
+       * @param {String} message _optional_
        * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Error#Error_types
        * @api public
        */
 
-      function assertThrows (constructor, msg) {
+      function assertThrows (constructor, errMsg, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
-        new Assertion(obj).is.a('function');
+        new Assertion(obj, msg).is.a('function');
 
         var thrown = false
           , desiredError = null
-          , name = null;
+          , name = null
+          , thrownError = null;
 
         if (arguments.length === 0) {
-          msg = null;
+          errMsg = null;
           constructor = null;
         } else if (constructor && (constructor instanceof RegExp || 'string' === typeof constructor)) {
-          msg = constructor;
+          errMsg = constructor;
           constructor = null;
         } else if (constructor && constructor instanceof Error) {
           desiredError = constructor;
           constructor = null;
-          msg = null;
+          errMsg = null;
         } else if (typeof constructor === 'function') {
           name = (new constructor()).name;
         } else {
@@ -1198,38 +1336,43 @@
           if (constructor) {
             this.assert(
                 err instanceof constructor
-              , 'expected #{this} to throw ' + name + ' but a ' + err.name + ' was thrown'
-              , 'expected #{this} to not throw ' + name );
-            if (!msg) return this;
+              , 'expected #{this} to throw ' + name + ' but ' + _.inspect(err) + ' was thrown'
+              , 'expected #{this} to not throw ' + name + ' but ' + _.inspect(err) + ' was thrown');
+            if (!errMsg) return this;
           }
           // next, check message
-          if (err.message && msg && msg instanceof RegExp) {
+          if (err.message && errMsg && errMsg instanceof RegExp) {
             this.assert(
-                msg.exec(err.message)
-              , 'expected #{this} to throw error matching ' + msg + ' but got ' + _.inspect(err.message)
-              , 'expected #{this} to throw error not matching ' + msg
+                errMsg.exec(err.message)
+              , 'expected #{this} to throw error matching ' + errMsg + ' but got ' + _.inspect(err.message)
+              , 'expected #{this} to throw error not matching ' + errMsg
             );
             return this;
-          } else if (err.message && msg && 'string' === typeof msg) {
+          } else if (err.message && errMsg && 'string' === typeof errMsg) {
             this.assert(
-                ~err.message.indexOf(msg)
+                ~err.message.indexOf(errMsg)
               , 'expected #{this} to throw error including #{exp} but got #{act}'
               , 'expected #{this} to throw error not including #{act}'
-              , msg
+              , errMsg
               , err.message
             );
             return this;
           } else {
             thrown = true;
+            thrownError = err;
           }
         }
 
         var expectedThrown = name ? name : desiredError ? _.inspect(desiredError) : 'an error';
+        var actuallyGot = ''
+        if (thrown) {
+          actuallyGot = ' but ' + _.inspect(thrownError) + ' was thrown'
+        }
 
         this.assert(
             thrown === true
-          , 'expected #{this} to throw ' + expectedThrown
-          , 'expected #{this} to not throw ' + expectedThrown
+          , 'expected #{this} to throw ' + expectedThrown + actuallyGot
+          , 'expected #{this} to not throw ' + expectedThrown + actuallyGot
         );
       };
 
@@ -1254,10 +1397,12 @@
        *
        * @name respondTo
        * @param {String} method
+       * @param {String} message _optional_
        * @api public
        */
 
-      Assertion.addMethod('respondTo', function (method) {
+      Assertion.addMethod('respondTo', function (method, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object')
           , itself = flag(this, 'itself')
           , context = ('function' === typeof obj && !itself)
@@ -1300,10 +1445,12 @@
        *
        * @name satisfy
        * @param {Function} matcher
+       * @param {String} message _optional_
        * @api public
        */
 
-      Assertion.addMethod('satisfy', function (matcher) {
+      Assertion.addMethod('satisfy', function (matcher, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
         this.assert(
             matcher(obj)
@@ -1324,10 +1471,12 @@
        * @name closeTo
        * @param {Number} expected
        * @param {Number} delta
+       * @param {String} message _optional_
        * @api public
        */
 
-      Assertion.addMethod('closeTo', function (expected, delta) {
+      Assertion.addMethod('closeTo', function (expected, delta, msg) {
+        if (msg) flag(this, 'message', msg);
         var obj = flag(this, 'object');
         this.assert(
             Math.abs(obj - expected) <= delta
@@ -2285,6 +2434,25 @@
           , 'expected ' + util.inspect(val) + ' to not be ' + operator + ' ' + util.inspect(val2) );
       };
 
+      /**
+       * ### .closeTo(actual, expected, delta, [message])
+       *
+       * Asserts that the target is equal `expected`, to within a +/- `delta` range.
+       *
+       *     assert.closeTo(1.5, 1, 0.5, 'numbers are close');
+       *
+       * @name closeTo
+       * @param {Number} actual
+       * @param {Number} expected
+       * @param {Number} delta
+       * @param {String} message
+       * @api public
+       */
+
+      assert.closeTo = function (act, exp, delta, msg) {
+        new Assertion(act, msg).to.be.closeTo(exp, delta);
+      };
+
       /*!
        * Undocumented / untested
        */
@@ -2336,7 +2504,21 @@
       function loadShould () {
         // modify Object.prototype to have `should`
         Object.defineProperty(Object.prototype, 'should',
-          { set: function () {}
+          {
+            set: function (value) {
+              // See https://github.com/chaijs/chai/issues/86: this makes
+              // `whatever.should = someValue` actually set `someValue`, which is
+              // especially useful for `global.should = require('chai').should()`.
+              //
+              // Note that we have to use [[DefineProperty]] instead of [[Put]]
+              // since otherwise we would trigger this very setter!
+              Object.defineProperty(this, 'should', {
+                value: value,
+                enumerable: true,
+                configurable: true,
+                writable: true
+              });
+            }
           , get: function(){
               if (this instanceof String || this instanceof Number) {
                 return new Assertion(this.constructor(this));
@@ -2350,31 +2532,31 @@
 
         var should = {};
 
-        should.equal = function (val1, val2) {
-          new Assertion(val1).to.equal(val2);
+        should.equal = function (val1, val2, msg) {
+          new Assertion(val1, msg).to.equal(val2);
         };
 
-        should.Throw = function (fn, errt, errs) {
-          new Assertion(fn).to.Throw(errt, errs);
+        should.Throw = function (fn, errt, errs, msg) {
+          new Assertion(fn, msg).to.Throw(errt, errs);
         };
 
-        should.exist = function (val) {
-          new Assertion(val).to.exist;
+        should.exist = function (val, msg) {
+          new Assertion(val, msg).to.exist;
         }
 
         // negation
         should.not = {}
 
-        should.not.equal = function (val1, val2) {
-          new Assertion(val1).to.not.equal(val2);
+        should.not.equal = function (val1, val2, msg) {
+          new Assertion(val1, msg).to.not.equal(val2);
         };
 
-        should.not.Throw = function (fn, errt, errs) {
-          new Assertion(fn).to.not.Throw(errt, errs);
+        should.not.Throw = function (fn, errt, errs, msg) {
+          new Assertion(fn, msg).to.not.Throw(errt, errs);
         };
 
-        should.not.exist = function (val) {
-          new Assertion(val).to.not.exist;
+        should.not.exist = function (val, msg) {
+          new Assertion(val, msg).to.not.exist;
         }
 
         should['throw'] = should['Throw'];
@@ -2471,7 +2653,7 @@
      */
 
     /**
-     * ### addMethod (ctx, name, method)
+     * ### .addMethod (ctx, name, method)
      *
      * Adds a method to the prototype of an object.
      *
@@ -2549,22 +2731,23 @@
   }); // module: chai/utils/addProperty.js
 
   require.register("chai/utils/eql.js", function(module, exports, require){
-    // This is directly from Node.js assert
+    // This is (almost) directly from Node.js assert
     // https://github.com/joyent/node/blob/f8c335d0caf47f16d31413f89aa28eda3878e3aa/lib/assert.js
-
 
     module.exports = _deepEqual;
 
-    // For browser implementation
-    if (!Buffer) {
-      var Buffer = {
-        isBuffer: function () {
-          return false;
-        }
+    // for the browser
+    var Buffer;
+    try {
+      Buffer = require('buffer').Buffer;
+    } catch (ex) {
+      Buffer = {
+        isBuffer: function () { return false; }
       };
     }
 
-    function _deepEqual(actual, expected) {
+    function _deepEqual(actual, expected, memos) {
+
       // 7.1. All identical values are equivalent, as determined by ===.
       if (actual === expected) {
         return true;
@@ -2595,7 +2778,7 @@
       // corresponding key, and an identical 'prototype' property. Note: this
       // accounts for both named and indexed properties on Arrays.
       } else {
-        return objEquiv(actual, expected);
+        return objEquiv(actual, expected, memos);
       }
     }
 
@@ -2607,11 +2790,25 @@
       return Object.prototype.toString.call(object) == '[object Arguments]';
     }
 
-    function objEquiv(a, b) {
+    function objEquiv(a, b, memos) {
       if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
         return false;
+
       // an identical 'prototype' property.
       if (a.prototype !== b.prototype) return false;
+
+      // check if we have already compared a and b
+      var i;
+      if (memos) {
+        for(i = 0; i < memos.length; i++) {
+          if ((memos[i][0] === a && memos[i][1] === b) ||
+              (memos[i][0] === b && memos[i][1] === a))
+            return true;
+        }
+      } else {
+        memos = [];
+      }
+
       //~~~I've managed to break Object.keys through screwy arguments passing.
       //   Converting to array solves the problem.
       if (isArguments(a)) {
@@ -2620,19 +2817,21 @@
         }
         a = pSlice.call(a);
         b = pSlice.call(b);
-        return _deepEqual(a, b);
+        return _deepEqual(a, b, memos);
       }
       try {
         var ka = Object.keys(a),
             kb = Object.keys(b),
-            key, i;
+            key;
       } catch (e) {//happens when one is a string literal and the other isn't
         return false;
       }
+
       // having the same number of owned properties (keys incorporates
       // hasOwnProperty)
       if (ka.length != kb.length)
         return false;
+
       //the same set of keys (although not necessarily the same order),
       ka.sort();
       kb.sort();
@@ -2641,14 +2840,20 @@
         if (ka[i] != kb[i])
           return false;
       }
+
+      // remember objects we have compared to guard against circular references
+      memos.push([ a, b ]);
+
       //equivalent values for every corresponding key, and
       //~~~possibly expensive deep test
       for (i = ka.length - 1; i >= 0; i--) {
         key = ka[i];
-        if (!_deepEqual(a[key], b[key])) return false;
+        if (!_deepEqual(a[key], b[key], memos)) return false;
       }
+
       return true;
     }
+
   }); // module: chai/utils/eql.js
 
   require.register("chai/utils/flag.js", function(module, exports, require){
@@ -2705,7 +2910,7 @@
 
     module.exports = function (obj, args) {
       var actual = args[4];
-      return 'undefined' !== actual ? actual : obj.obj;
+      return 'undefined' !== typeof actual ? actual : obj._obj;
     };
 
   }); // module: chai/utils/getActual.js
@@ -2723,10 +2928,11 @@
 
     var flag = require('./flag')
       , getActual = require('./getActual')
-      , inspect = require('./inspect');
+      , inspect = require('./inspect')
+      , objDisplay = require('./objDisplay');
 
     /**
-     * # getMessage(object, message, negateMessage)
+     * ### .getMessage(object, message, negateMessage)
      *
      * Construct the error message based on flags
      * and template tags. Template tags will return
@@ -2739,6 +2945,8 @@
      *
      * @param {Object} object (constructed Assertion)
      * @param {Arguments} chai.Assertion.prototype.assert arguments
+     * @name getMessage
+     * @api public
      */
 
     module.exports = function (obj, args) {
@@ -2751,9 +2959,9 @@
 
       msg = msg || '';
       msg = msg
-        .replace(/#{this}/g, inspect(val))
-        .replace(/#{act}/g, inspect(actual))
-        .replace(/#{exp}/g, inspect(expected));
+        .replace(/#{this}/g, objDisplay(val))
+        .replace(/#{act}/g, objDisplay(actual))
+        .replace(/#{exp}/g, objDisplay(expected));
 
       return flagMsg ? flagMsg + ': ' + msg : msg;
     };
@@ -2928,6 +3136,12 @@
     exports.inspect = require('./inspect');
 
     /*!
+     * Object Display util
+     */
+
+    exports.objDisplay = require('./objDisplay');
+
+    /*!
      * Flag utility
      */
 
@@ -3018,6 +3232,36 @@
       return formatValue(ctx, obj, (typeof depth === 'undefined' ? 2 : depth));
     }
 
+    // https://gist.github.com/1044128/
+    var getOuterHTML = function(element) {
+      if ('outerHTML' in element) return element.outerHTML;
+      var ns = "http://www.w3.org/1999/xhtml";
+      var container = document.createElementNS(ns, '_');
+      var elemProto = (window.HTMLElement || window.Element).prototype;
+      var xmlSerializer = new XMLSerializer();
+      var html;
+      if (document.xmlVersion) {
+        return xmlSerializer.serializeToString(element);
+      } else {
+        container.appendChild(element.cloneNode(false));
+        html = container.innerHTML.replace('><', '>' + element.innerHTML + '<');
+        container.innerHTML = '';
+        return html;
+      }
+    };
+      
+    // Returns true if object is a DOM element.
+    var isDOMElement = function (object) {
+      if (typeof HTMLElement === 'object') {
+        return object instanceof HTMLElement;
+      } else {
+        return object &&
+          typeof object === 'object' &&
+          object.nodeType === 1 &&
+          typeof object.nodeName === 'string';
+      }
+    };
+
     function formatValue(ctx, value, recurseTimes) {
       // Provide a hook for user-specified inspect functions.
       // Check that value is an object with an inspect function on it
@@ -3033,6 +3277,11 @@
       var primitive = formatPrimitive(ctx, value);
       if (primitive) {
         return primitive;
+      }
+
+      // If it's DOM elem, get outer HTML.
+      if (isDOMElement(value)) {
+        return getOuterHTML(value);
       }
 
       // Look up the keys of the object.
@@ -3272,6 +3521,54 @@
     }
 
   }); // module: chai/utils/inspect.js
+
+  require.register("chai/utils/objDisplay.js", function(module, exports, require){
+    /*!
+     * Chai - flag utility
+     * Copyright(c) 2012 Jake Luer <jake@alogicalparadox.com>
+     * MIT Licensed
+     */
+
+    /*!
+     * Module dependancies
+     */
+
+    var inspect = require('./inspect');
+
+    /**
+     * ### .objDisplay (object)
+     *
+     * Determines if an object or an array matches
+     * criteria to be inspected in-line for error
+     * messages or should be truncated.
+     *
+     * @param {Mixed} javascript object to inspect
+     * @name objDisplay
+     * @api public
+     */
+
+    module.exports = function (obj) {
+      var str = inspect(obj)
+        , type = Object.prototype.toString.call(obj);
+
+      if (str.length >= 40) {
+        if (type === '[object Array]') {
+          return '[ Array(' + obj.length + ') ]';
+        } else if (type === '[object Object]') {
+          var keys = Object.keys(obj)
+            , kstr = keys.length > 2
+              ? keys.splice(0, 2).join(', ') + ', ...'
+              : keys.join(', ');
+          return '{ Object (' + kstr + ') }';
+        } else {
+          return str;
+        }
+      } else {
+        return str;
+      }
+    };
+
+  }); // module: chai/utils/objDisplay.js
 
   require.register("chai/utils/overwriteMethod.js", function(module, exports, require){
     /*!


### PR DESCRIPTION
The old chai's `expect` is terribly slow when expecting dom element:

```
// chai.version === "1.1.0"
console.time('n')
expect(document.body).to.equal(document.body)
console.timeEnd('n')
// => n: 932.448ms
```

versus:

```
// chai.version == "1.4.0"
console.time('n')
expect(document.body).to.equal(document.body)
console.timeEnd('n')
// => 0.141ms
```
