### PR TITLE
Use forked grunt-lib-phantomjs for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "./node_modules/.bin/grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "~0.1.0"
+    "grunt-lib-phantomjs": "https://github.com/kmiyashiro/grunt-lib-phantomjs/tarball/master"
   },
   "devDependencies": {
     "grunt": "~0.4.0a",


### PR DESCRIPTION
Fixes the devel branch while we wait on the status of [your pull request](https://github.com/gruntjs/grunt-lib-phantomjs/pull/4). Would obviously need to be removed later.
