### PR TITLE
Use Mocha reporters to add information on screen

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,8 +8,6 @@ module.exports = function(grunt) {
 
   var port = 8981;
 
-  grunt.loadNpmTasks('grunt-contrib-connect');
-
   grunt.initConfig({
     jshint: {
       all: [
@@ -22,8 +20,14 @@ module.exports = function(grunt) {
     watch: {
       // If you want to watch files and run tests automatically on change
       test: {
-        files: ['example/js/**/*.js', 'example/test/spec/**/*.js'],
-        tasks: 'mocha'
+        files: [
+          'example/js/**/*.js',
+          'example/test/spec/**/*.js',
+          'phantomjs/*',
+          'tasks/*',
+          'Gruntfile.js'
+        ],
+        tasks: 'test'
       }
     },
     mocha: {
@@ -48,6 +52,8 @@ module.exports = function(grunt) {
             grep: 'food'
           },
 
+          reporter: 'Spec',
+
           // Indicates whether 'mocha.run()' should be executed in 
           // 'bridge.js'
           run: true
@@ -64,6 +70,8 @@ module.exports = function(grunt) {
             ignoreLeaks: false,
             grep: 'food'
           },
+
+          reporter: 'Nyan',
 
           // URLs passed through as options
           urls: ['http://localhost:' + port + '/example/test/test2.html'],
@@ -90,7 +98,6 @@ module.exports = function(grunt) {
   // These plugins provide necessary tasks.
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-internal');
 
   // Alias 'test' to 'mocha' so you can run `grunt test`
   grunt.task.registerTask('test', ['connect', 'mocha']);

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ mocha: {
                 grep: 'food'
             },
 
+            // Select a Mocha reporter - http://visionmedia.github.com/mocha/#reporters
+            reporter: 'Nyan',
+
             // Indicates whether 'mocha.run()' should be executed in 
             // 'bridge.js'. If you include `mocha.run()` in your html spec, you
             // must wrap it in a conditional check to not run if it is opened
@@ -119,10 +122,6 @@ This task is for running Mocha tests in a headless browser, PhantomJS. [See the 
 ### Mocha
 
 Use [Mocha](http://visionmedia.github.com/mocha/)
-
-### Maybe Growl?
-
-Growl support is optional. I'm not sure what the Windows situation is with growl.
 
 ### Hacks
 

--- a/package.json
+++ b/package.json
@@ -29,16 +29,14 @@
     "test": "./node_modules/.bin/grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "0.2.0"
+    "grunt-lib-phantomjs": "~0.2",
+    "mocha": "~1.8",
+    "lodash": "~1.0"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
-    "grunt-contrib-connect": "~0.1",
-    "grunt-contrib-internal": "*",
-    "grunt-contrib-jshint": "~0.1.0"
-  },
-  "optionalDependencies": {
-    "growl": "~1"
+    "grunt": "~0.4",
+    "grunt-contrib-connect": "~0.2",
+    "grunt-contrib-jshint": "~0.3"
   },
   "keywords": [
     "gruntplugin mocha test phantomjs"

--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -12,114 +12,65 @@
  * http://benalman.com/about/license/
  */
 
- 'use strict';
+'use strict';
 
 module.exports = function(grunt) {
   // Nodejs libs.
   var path = require('path');
+  var EventEmitter = require('events').EventEmitter;
 
   // External lib.
+  var _ = require('lodash');
   var phantomjs = require('grunt-lib-phantomjs').init(grunt);
-  
-  var growl;
-  // Growl is optional
-  try {
-    growl = require('growl');
-  } catch(e) {
-    growl = function(){};
-    grunt.verbose.write('Growl not found, npm install growl for Growl support');
-  }
-
-  // Keep track of the last-started module, test and status.
-  var currentModule, currentTest, status;
-  // Keep track of the last-started test(s).
-  var unfinished = {};
+  var reporters = require('mocha').reporters;
+  var reporter;
 
   // Get an asset file, local to the root of the project.
   var asset = path.join.bind(null, __dirname, '..');
 
-  // Allow an error message to retain its color when split across multiple lines.
-  function formatMessage(str) {
-    return String(str).split('\n').map(function(s) { return s.magenta; }).join('\n');
-  }
+  // Manage runners listening to phantomjs
+  var phantomjsEventManager = (function() {
+    var listeners = {};
 
-  // Keep track of failed assertions for pretty-printing.
-  var failedAssertions = [];
-  function logFailedAssertions() {
-    var assertion;
-    // Print each assertion error.
-    while (assertion = failedAssertions.shift()) {
-      grunt.verbose.or.error(assertion.testName);
-      grunt.log.error('Message: ' + formatMessage(assertion.message));
-      if (assertion.actual !== assertion.expected) {
-        grunt.log.error('Actual: ' + formatMessage(assertion.actual));
-        grunt.log.error('Expected: ' + formatMessage(assertion.expected));
+    // Hook on Phantomjs Mocha reporter events.
+    phantomjs.on('mocha.*', function(test) {
+      var name, fullTitle, slow, err;
+      var evt = this.event.replace('mocha.', '');
+
+      if (evt === 'end') {
+        phantomjs.halt();
       }
-      if (assertion.source) {
-        grunt.log.error(assertion.source.replace(/ {4}(at)/g, '  $1'));
+
+      // Expand test values (and façace the Mocha test object)
+      if( test ) {
+        fullTitle = test.fullTitle;
+        test.fullTitle = function() {
+          return fullTitle;
+        };
+
+        slow = this.slow;
+        test.slow = function() {
+          return slow;
+        };
+
+        err = test.err;
       }
-      grunt.log.writeln();
-    }
-  }
 
-  // Mocha hooks.
-  phantomjs.on('mocha.suiteStart', function(name) {
-    unfinished[name] = true;
-    currentModule = name;
-  });
-
-  phantomjs.on('mocha.suiteDone', function(name, failed, passed, total) {
-    delete unfinished[name];
-  });
-
-  phantomjs.on('mocha.testStart', function(name) {
-    currentTest = (currentModule ? currentModule + ' - ' : '') + name;
-    grunt.verbose.write(currentTest + '...');
-  });
-
-  phantomjs.on('mocha.testFail', function(name, result) {
-      result.testName = currentTest;
-      failedAssertions.push(result);
-  });
-
-  phantomjs.on('mocha.testDone', function(title, state) {
-    // Log errors if necessary, otherwise success.
-    if (state === 'failed') {
-      // list assertions
-      if (grunt.option('verbose')) {
-        grunt.log.error();
-        logFailedAssertions();
-      } else {
-        grunt.log.write('F'.red);
+      // Trigger events for each runner listening
+      for( name in listeners ) {
+        listeners[name].emit.call(listeners[name], evt, test, err);
       }
-    } else {
-      grunt.verbose.ok().or.write('.');
-    }
-  });
+    });
 
-  phantomjs.on('mocha.done', function(failed, passed, total, duration) {
-    phantomjs.halt();
-    var nDuration = parseFloat(duration) || 0;
-    status.failed += failed;
-    status.passed += passed;
-    status.total += total;
-    status.duration += Math.round(nDuration*100)/100;
-    // Print assertion errors here, if verbose mode is disabled.
-    if (!grunt.option('verbose')) {
-      if (failed > 0) {
-        grunt.log.writeln();
-        logFailedAssertions();
-      } else {
-        grunt.log.ok();
+    return {
+      add: function(name, runner) {
+        listeners[name] = runner;
+      },
+      remove: function(name) {
+        delete listeners[name];
       }
-    }
-  });
-
-  // Re-broadcast qunit events on grunt.event.
-  phantomjs.on('mocha.*', function() {
-    var args = [this.event].concat(grunt.util.toArray(arguments));
-    grunt.event.emit.apply(grunt.event, args);
-  });
+    };
+  }());
 
   // Built-in error handlers.
   phantomjs.on('fail.load', function(url) {
@@ -137,10 +88,10 @@ module.exports = function(grunt) {
 
   
   // console.log pass-through.
-  phantomjs.on('console', console.log.bind(console));
+  // phantomjs.on('console', grunt.log.writeln.bind(grunt.log));
 
   // Debugging messages.
-  // phantomjs.on('debug', grunt.log.debug.bind(log, 'phantomjs')
+  // phantomjs.on('debug', grunt.log.debug.bind(grunt.log, 'phantomjs'));
 
   // ==========================================================================
   // TASKS
@@ -149,6 +100,8 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('mocha', 'Run Mocha unit tests in a headless PhantomJS instance.', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
+      // Mocha reporter
+      reporter: 'Dot',
       // Default PhantomJS timeout.
       timeout: 5000,
       // Mocha-PhantomJS bridge file to be injected.
@@ -159,7 +112,10 @@ module.exports = function(grunt) {
       urls: []
     });
 
-    var configStr = JSON.stringify(options);
+    // Clean Phantomjs options to prevent any conflicts
+    var PhantomjsOptions = _.omit(options, 'reporter', 'urls');
+
+    var configStr = JSON.stringify(PhantomjsOptions, null, '  ');
     grunt.verbose.writeln('Additional configuration: ' + configStr);
 
     // Combine any specified URLs with src files.
@@ -168,29 +124,40 @@ module.exports = function(grunt) {
     // This task is asynchronous.
     var done = this.async();
 
-    // Reset status.
-    status = {failed: 0, passed: 0, total: 0, duration: 0};
-
     // Process each filepath in-order.
     grunt.util.async.forEachSeries(urls, function(url, next) {
-      var basename = path.basename(url);
-      grunt.verbose.subhead('Testing ' + basename).or.write('Testing ' + basename);
+      grunt.log.writeln('Testing: ' + url);
 
-      // Reset current module.
-      currentModule = null;
+      // create a new mocha runner façade
+      var runner = new EventEmitter();
+      phantomjsEventManager.add(url, runner);
+
+      // Clear runner event listener when test is over
+      runner.on('end', function() {
+        phantomjsEventManager.remove(url);
+      });
+
+      // Set Mocha reporter
+      var Reporter = reporters[ options.reporter ];
+      if( Reporter == null ) { grunt.fail.fatal('Reporter specified is unknown'); }
+      reporter = new Reporter(runner);
 
       // Launch PhantomJS.
       phantomjs.spawn(url, {
         // Exit code to use if PhantomJS fails in an uncatchable way.
         failCode: 90,
         // Additional PhantomJS options.
-        options: options,
+        options: PhantomjsOptions,
         // Do stuff when done.
         done: function(err) {
           if (err) {
             // If there was an error, abort the series.
+            grunt.fail.fatal( err );
             done();
           } else {
+            if( runner.stats.failures > 0 ) {
+              grunt.fail.warn('An error occured in your tests');
+            }
             // Otherwise, process next url.
             next();
           }
@@ -199,25 +166,6 @@ module.exports = function(grunt) {
     },
     // All tests have been run.
     function() {
-      // Log results.
-      if (status.failed > 0) {
-        growl(status.failed + ' of ' + status.total + ' tests failed!', {
-          image: asset('growl/error.png'),
-          title: 'Tests Failed',
-          priority: 3
-        });
-        grunt.warn(status.failed + '/' + status.total + ' assertions failed (' +
-          status.duration + 's)', Math.min(99, 90 + status.failed));
-      } else {
-        growl('All Clear: ' + status.total + ' tests passed', {
-          title: 'Tests Passed',
-          image: asset('growl/ok.png')
-        });
-        grunt.verbose.writeln();
-        grunt.log.ok(status.total + ' assertions passed (' + status.duration + 's)');
-      }
-
-      // All done!
       done();
     });
   });


### PR DESCRIPTION
Hi,

I've been switching the growl + custom info logging to the Mocha defaults reporters. Mocha allow a lot of pretty, usefull and colorfull reporters, I found that this was missing from the Phantomjs/grunt version.

This needed quite a lot of changes, now every Mocha events occuring inside Phantomjs is bubbled to the Grunt runner where we "façade" some Mocha test/suite property/functions in order to make it run through a reporter.

The results are good by my side and it's been working with every reporter I've tested.

Let me know what you think!
