### PR TITLE
Run all specified test urls before grunt warning

### DIFF
--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -134,6 +134,12 @@ module.exports = function(grunt) {
     // This task is asynchronous.
     var done = this.async();
 
+    // Initialize test statistics.
+    var totalStats = {
+      failures: 0,
+      duration: 0,
+      tests: 0
+    };
     // Process each filepath in-order.
     grunt.util.async.forEachSeries(urls, function(url, next) {
       grunt.log.writeln('Testing: ' + url);
@@ -154,11 +160,6 @@ module.exports = function(grunt) {
       }
       reporter = new Reporter(runner);
 
-      var totalStats = {
-        failures: 0,
-        duration: 0,
-        tests: 0
-      };
       // Launch PhantomJS.
       phantomjs.spawn(url, {
         // Exit code to use if PhantomJS fails in an uncatchable way.
@@ -191,8 +192,7 @@ module.exports = function(grunt) {
     // All tests have been run.
     function() {
       if (totalStats.failures > 0) {
-        var duration = totalStats.duration + 'ms';
-        var failMsg = totalStats.failures + '/' + totalStats.tests + ' tests failed (' + duration + ')';
+        var failMsg = totalStats.failures + '/' + totalStats.tests + ' tests failed (' + totalStats.duration + 'ms)';
 
         // Show Growl notice, if avail
         growl(failMsg, {


### PR DESCRIPTION
This simply runs all specified tests in the urls option, aggregates all the stats and calls grunt.warn() after all tests are run (as opposed to after the first test html that fails). As far as I can tell the --bail option isn't currently supported by grunt-mocha right now anyway so this would make it more consistent by always expecting all the tests to be run before warning and reporting that there are test failures. In the future we could also add a --bail option to grunt-mocha which would simply stop at the first failure.
