### PR TITLE
Growl notify on success

### DIFF
--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -196,6 +196,12 @@ module.exports = function(grunt) {
     },
     // All tests have been run.
     function() {
+      var okMsg = urls.length + '/' + urls.length + ' passed!';
+      growl(okMsg, {
+        image: asset('growl/ok.png'),
+        title: 'OK',
+        priority: 3
+      });
       done();
     });
   });


### PR DESCRIPTION
This way you can see when all your tests are passing, which is helpfully if they were just failing... you get instant feedback if you're using it in conjunction with some kind of fs watch / runner.
