### PR TITLE
Added support for custom reporters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,6 +80,19 @@ module.exports = function(grunt) {
         }
       },
 
+      // Test using a custom reporter
+      testReporter: {
+        src: ['example/test/test.html', 'example/test/test2.html'],
+        options: {
+          mocha: {
+            ignoreLeaks: false,
+            grep: 'food'
+          },
+          reporter: './example/test/reporter/simple',
+          run: true
+        }
+      },
+
       // Test a failing test with bail: true
       testBail: {
         src: ['example/test/testBail.html'],

--- a/example/test/reporter/simple.js
+++ b/example/test/reporter/simple.js
@@ -1,0 +1,53 @@
+module.exports = function (runner) {
+  var failures = runner.failures = [];
+
+  var stats = runner.stats = {
+    suites: 0,
+    tests: 0,
+    passes: 0,
+    pending: 0,
+    failures: 0,
+    duration: 0,
+    start: 0,
+    end: 0
+  };
+
+  runner.on('start', function () {
+    console.log('-> start');
+    stats.start = new Date().getTime();
+  });
+
+  runner.on('test', function (test) {
+    stats.tests++;
+  });
+
+  runner.on('suite', function (suite) {
+    stats.suites++;
+  });
+
+  runner.on('suite end', function (suite) {
+  });
+
+  runner.on('pending', function (test) {
+    stats.pending++;
+    console.log('?  pending: %s', test.fullTitle());
+  });
+
+  runner.on('pass', function (test) {
+    stats.passes++;
+    console.log('-> pass: %s', test.fullTitle());
+  });
+
+  runner.on('fail', function (test, err) {
+    stats.failures++;
+    test.err = err;
+    failures.push(test);
+    console.log('!! fail: %s -- error: %s', test.fullTitle(), err.message);
+  });
+
+  runner.on('end', function () {
+    stats.end = new Date().getTime();
+    stats.duration = (stats.end - stats.start);
+    console.log('-> end: %d/%d', stats.passes, stats.passes + stats.failures);
+  });
+};

--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -164,11 +164,25 @@ module.exports = function(grunt) {
       if (reporters[options.reporter]) {
         Reporter = reporters[options.reporter];
       }
-      else if (require.resolve(options.reporter)) {
-        Reporter = require(options.reporter);
+      else {
+        // Resolve external reporter module
+        var p;
+        try {
+          p = require.resolve(options.reporter);
+        }
+        catch (e) {
+          // Resolve to local path
+          p = path.resolve(options.reporter);
+        }
+        if (p) {
+          try {
+            Reporter = require(p);
+          }
+          catch (e) { }
+        }
       }
       if (Reporter === null) {
-        grunt.fatal('Specified reporter is unknown: ' + options.reporter);
+        grunt.fatal('Specified reporter is unknown or unresolvable: ' + options.reporter);
       }
       reporter = new Reporter(runner);
 


### PR DESCRIPTION
Mocha's node module allows us to use a custom reporter by passing the module name as the `reporter` option.

I use this in `grunt-mocha-test` but needed it in `grunt-mocha` as well so here is a fix to implement it. I use it with [this](https://github.com/Bartvds/mocha-unfunk-reporter) reporter.
