### PR TITLE
Add timeout to test #2 and README

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,7 +56,9 @@ module.exports = function(grunt) {
 
           // Indicates whether 'mocha.run()' should be executed in
           // 'bridge.js'
-          run: true
+          run: true,
+
+          timeout: 10000
         }
       },
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ mocha: {
       // Indicates whether 'mocha.run()' should be executed in
       // 'bridge.js'. If you include `mocha.run()` in your html spec,
       // check if environment is PhantomJS. See example/test/test2.html
-      run: true
+      run: true,
+
+      // Override the timeout of the test (default is 5000)
+      timeout: 10000
     }
   },
 

--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -108,6 +108,7 @@ module.exports = function(grunt) {
   // ==========================================================================
 
   grunt.registerMultiTask('mocha', 'Run Mocha unit tests in a headless PhantomJS instance.', function() {
+
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
       // Output console.log calls


### PR DESCRIPTION
It wasn't clear in the docs that you could override the Mocha/PhantomJS default timeout of 5000ms, so I added that in there to solve this issue: https://github.com/kmiyashiro/grunt-mocha/issues/37
