### PR TITLE
Add an option to log uncaught script errors as grunt errors.

### DIFF
--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -109,13 +109,6 @@ module.exports = function(grunt) {
     grunt.warn('PhantomJS timed out, possibly due to a missing Mocha run() call.', 90);
   });
 
-  phantomjs.on('error.*', function(error, stack) {
-    var stack = _.map(stack, function(frame) {
-        return "    at " + (frame.function ? frame.function : "undefined") + " (" + frame.file + ":" + frame.line + ")";
-    }).join("\n");
-    grunt.log.error(error + "\n" + stack);
-  });
-
   // Debugging messages.
   // phantomjs.on('debug', grunt.log.debug.bind(grunt.log, 'phantomjs'));
 
@@ -140,12 +133,24 @@ module.exports = function(grunt) {
       // Explicit non-file URLs to test.
       urls: [],
       // Fail with grunt.warn on first test failure
-      bail: false
+      bail: false,
+      // Log script errors as grunt errors
+      logErrors: false
     });
 
     // console.log pass-through.
     if (options.log) {
       phantomjs.on('console', grunt.log.writeln.bind(grunt.log));
+    }
+
+    // error handler
+    if (options.logErrors) {
+        phantomjs.on('error.*', function(error, stack) {
+            var stack = _.map(stack, function(frame) {
+                return "    at " + (frame.function ? frame.function : "undefined") + " (" + frame.file + ":" + frame.line + ")";
+            }).join("\n");
+            grunt.log.error(error + "\n" + stack);
+        });
     }
 
     // Clean Phantomjs options to prevent any conflicts


### PR DESCRIPTION
Phantomjs emits events for uncaught exceptions in the source code, but these aren't handled by grunt-mocha. This means that a test may fail due to an exception, but there's no console indication as to what the problem is.

The patch adds an optional error handler that formats the error message and stack trace and then logs it as a grunt error. The option currently defaults to false -- personally, I would prefer to make the default true, however since that could break existing tests, I figured this was the more conservative route.
