### PR TITLE
Capture reporter output and direct to `dest` if defined

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,6 +107,30 @@ module.exports = function(grunt) {
         }
       },
 
+      testDest1: {
+        // Test files
+        src: ['example/test/test2.html'],
+        dest: 'example/test/results/spec.out',
+        options: {
+          reporter: 'Spec',
+          run: true
+        }
+      },
+
+      // Same as above, but with URLS + Xunit
+      testDest2: {
+        options: {
+          reporter: 'XUnit',
+
+          // URLs passed through as options
+          urls: ['http://localhost:' + port + '/example/test/test2.html'],
+
+          run: true
+        },
+        src: [],  // we need this since we use `dest`.
+        dest: 'example/test/results/xunit.out'
+      },
+
       // Test a failing test with bail: true
       testBail: {
         src: ['example/test/testBail.html'],
@@ -137,6 +161,24 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.registerTask('verify-test-results', function () {
+    var expected = ['spec', 'xunit'];
+
+    expected.forEach(function (reporter) {
+      var output = 'example/test/results/' + reporter + '.out';
+
+      // simply check if the file is non-empty since verifying if the output is
+      // correct based on the spec is kind of hard due to changing test running
+      // times and different ways to report this time in reporters.
+      if (!grunt.file.read(output, 'utf8'))
+        grunt.fatal('Empty reporter output: ' + reporter);
+
+      // Clean-up
+      grunt.file.delete(output);
+      grunt.log.ok('Reporter output non-empty for %s', reporter);
+    });
+  });
+
   // IMPORTANT: Actually load this plugin's task(s).
   // To use grunt-mocha, replace with grunt.loadNpmTasks('grunt-mocha')
   grunt.loadTasks('tasks');
@@ -147,7 +189,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-connect');
 
   // Alias 'test' to 'mocha' so you can run `grunt test`
-  grunt.task.registerTask('test', ['connect', 'mocha']);
+  grunt.task.registerTask('test', ['connect', 'mocha', 'verify-test-results']);
 
   // By default, lint and run all tests.
   grunt.task.registerTask('default', ['jshint', 'test']);


### PR DESCRIPTION
There's no way to capture the pure reporter output when running `grunt-mocha`. This patch hijacks(because there's no other better way) `console.log` right before running tests, and then puts the captured content into a file if `dest` is defined.
