### PR TITLE
Add missing test info to bridge

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -27,6 +27,8 @@
         if (test) {
           data.title = test.title;
           data.fullTitle = test.fullTitle();
+          data.duration = test.duration;
+          data.slow = test.slow;
         }
 
         sendMessage('mocha.' + ev, data);


### PR DESCRIPTION
Test duration and "is slow?" information was missing from the bridge so some reporters, _ahem_ XUnit _ahem_, were not able to report test durations. This patch fixes that.
