### PR TITLE
Correct README's placement of `bail` option in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ mocha: {
     // Test files
     src: [ 'example/test/test2.html' ],
     options: {
-      // Bail means if a test fails, grunt will abort. False by default.
-      bail: true,
-
       // Pipe output console.log from your JS to grunt. False by default.
       log: true,
 
       // mocha options
       mocha: {
+        // Bail means if a test fails, grunt will abort. False by default.
+        bail: true,
         ignoreLeaks: false,
         grep: 'food'
       },


### PR DESCRIPTION
`bail` didn't work for me place where it is in the README, as a property of the `options` object. It worked when a property of the `options.mocha` object. I've corrected the README to reflect this.
