### PR TITLE
fix exception when call mocha HTML reporter

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -36,10 +36,10 @@
       });
     }
 
-    var GruntReporter = function(runner){
-      // 1.4.2 moved reporters to Mocha instead of mocha
-      var mochaInstance = window.Mocha || window.mocha;
+    // 1.4.2 moved reporters to Mocha instead of mocha
+    var mochaInstance = window.Mocha || window.mocha;
 
+    var GruntReporter = function(runner){
       if (!mochaInstance) {
         throw new Error('Mocha was not found, make sure you include Mocha in your HTML spec file.');
       }
@@ -65,6 +65,10 @@
       }
 
     };
+
+    var Klass = function () {};
+    Klass.prototype = mochaInstance.reporters.HTML.prototype;
+    GruntReporter.prototype = new Klass();
 
     var options = window.PHANTOMJS;
     if (options) {


### PR DESCRIPTION
GruntReporter will rise an exception when initialize:

``` js
  mochaInstance.reporters.HTML.call(this, runner);
```

because `HTML` reporter will listen some event which need `suiteURL`
method:

``` js
  function HTML(runner, root) {
    // ...
    runner.on('suite', function(suite){
      // ...
      var url = self.suiteURL(suite); // will rise an exception
      // ...
    });
    // ...
  }
```

So make GruntReporter inherit HTML reporter to resolve this issue.
