### PR TITLE
call done() callback with success boolean

### DIFF
--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -231,7 +231,7 @@ module.exports = function(grunt) {
 
             // If there was a PhantomJS error, abort the series.
             grunt.fatal(err);
-            done();
+            done(false);
           } else {
             // If failures, show growl notice
             if (stats.failures > 0) {
@@ -276,6 +276,10 @@ module.exports = function(grunt) {
         });
 
         grunt.log.ok(okMsg);
+
+        // Async test pass
+        done(true);
+
       } else {
         var failMsg = stats.failures + '/' + stats.tests + ' tests failed (' +
           stats.duration + 's)';
@@ -293,10 +297,10 @@ module.exports = function(grunt) {
         } else {
           grunt.log.error(failMsg);
         }
-      }
 
-      // Async test done
-      done();
+        // Async test fail
+        done(false);
+      }
     });
   });
 };


### PR DESCRIPTION
In an older project I updated `grunt` to `v0.4.2` and `grunt-mocha`  but then the task (and so my build) doesn't fail when the tests fail:

```
...    
>> 3/6 tests failed (0.13s)

Done, without errors.
```

It is fixed by adding the status booleans to the done() call.

```
...    
>> 3/6 tests failed (0.12s)
Warning: Task "mocha:base" failed. Use --force to continue.

Aborted due to warnings.
```

It looks like `grunt` wasn't notified of failure by the log-features somehow. Adding the booleans makes the status more explicit, as per http://gruntjs.com/api/inside-tasks#this.async
