### PR TITLE
Hijack process.stdout as well as console.log

### DIFF
--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -165,11 +165,15 @@ module.exports = function(grunt) {
     var dest = this.data.dest;
     var output = [];
     var consoleLog = console.log;
+    // Latest mocha xunit reporter sends to process.stdout instead of console
+    var processWrite = process.stdout.write;
+
 
     // Only hijack if we really need to
     if (dest) {
       console.log = function() {
         consoleLog.apply(console, arguments);
+        processWrite.apply(process.stdout, arguments);
         output.push(util.format.apply(util, arguments));
       };
     }


### PR DESCRIPTION
The latest xunit reporter uses process.stdout instead of console.log.  We need to hijack stdout as well as console.
