### PR TITLE
Fix test state not being passed through the bridge

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -26,6 +26,7 @@
         if (test) {
           data.title = test.title;
           data.fullTitle = test.fullTitle();
+          data.state = test.state;
           data.duration = test.duration;
           data.slow = test.slow;
         }


### PR DESCRIPTION
Test state was not passed through the PhantomJS bridge causing XUnit output to not reflect test failures properly. This patch fixes that.
