### PR TITLE
Make Growl notifications on success an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ mocha: {
 },
 ```
 
+#### options.growlOnSuccess
+Type: `Boolean`
+Default: `true`
+
+Display a Growl notification when all tests successfully pass.
+
+Example:
+```js
+mocha: {
+  test: {
+    src: ['tests/**/*.html'],
+    options: {
+      growlOnSuccess: false,
+    },
+  },
+},
+```
+
 #### options.log
 Type: `Boolean`  
 Default: `false`

--- a/tasks/mocha.js
+++ b/tasks/mocha.js
@@ -134,7 +134,9 @@ module.exports = function(grunt) {
       // Fail with grunt.warn on first test failure
       bail: false,
       // Log script errors as grunt errors
-      logErrors: false
+      logErrors: false,
+      // Growl notification when tests pass.
+      growlOnSuccess: true
     });
 
     // Output console messages if log == true
@@ -286,11 +288,13 @@ module.exports = function(grunt) {
       if (stats.failures === 0) {
         var okMsg = stats.tests + ' passed!' + ' (' + stats.duration + 's)';
 
-        growl(okMsg, {
-          image: asset('growl/ok.png'),
-          title: okMsg,
-          priority: 3
-        });
+        if (options.growlOnSuccess) {
+          growl(okMsg, {
+            image: asset('growl/ok.png'),
+            title: okMsg,
+            priority: 3
+          });
+        }
 
         grunt.log.ok(okMsg);
 


### PR DESCRIPTION
It's a bit noisy to have Growl notifications when tests pass. This will
allow people to show notifications only for issues.
