### PR TITLE
Fix deploys errors since BitBucket's URL update

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "./node_modules/.bin/grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "~0.6.0",
     "mocha": "~1.18",
     "lodash": "~2.3.0"
   },
@@ -39,7 +38,8 @@
   "devDependencies": {
     "grunt": "~0.4",
     "grunt-contrib-connect": "~0.2",
-    "grunt-contrib-jshint": "~0.3"
+    "grunt-contrib-jshint": "~0.3",
+    "grunt-lib-phantomjs": "~0.6.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Update this lib to get last PhantomJS version which resolves PhantomJS issue [161](https://github.com/Medium/phantomjs/issues/161). :yum: 
