### PR TITLE
Support outputting HTML code coverage from PhantomJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -130,6 +130,16 @@ module.exports = function(grunt) {
         dest: 'example/test/results/xunit.out'
       },
 
+      testCoverage: {
+        options: {
+          reporter: 'HTMLCov',
+          run: false,
+          waitForCoverage: true,
+          urls: ['http://localhost:' + port + '/example/test/testCoverage.html']
+        },
+        dest: 'example/test/results/coverage.html'
+      },
+
       // Test a failing test with bail: true
       testBail: {
         src: ['example/test/testBail.html'],
@@ -203,6 +213,7 @@ module.exports = function(grunt) {
     'mocha:testDest2',
     'verifyDestResults'
   ]);
+  grunt.task.registerTask('testCoverage', ['connect:testUrls', 'mocha:testCoverage']);
   // WARNING: Running this test will cause grunt to fail after mocha:testBail
   grunt.task.registerTask('testBail', ['mocha:testBail', 'mocha:neverTest']);
   grunt.task.registerTask('test', [
@@ -211,6 +222,7 @@ module.exports = function(grunt) {
     'testLog',
     'testReporter',
     'testDest',
+    'testCoverage',
     'testBail'
   ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
       // In this example, there's only one, but you can add as many as
       // you want. You can split them up into different groups here
       // ex: admin: [ 'test/admin.html' ]
-      all: ['example/test/**/!(test2|testBail).html'],
+      all: ['example/test/**/!(test2|testBail|coverage).html'],
 
       // Runs 'test/test2.html' with specified mocha options.
       // This variant auto-includes 'bridge.js' so you do not have
@@ -172,6 +172,12 @@ module.exports = function(grunt) {
           port: port + 1,
           base: '.'
         }
+      },
+      testCoverage: {
+        options: {
+          port: port + 2,
+          base: '.'
+        }
       }
     }
   });
@@ -213,7 +219,7 @@ module.exports = function(grunt) {
     'mocha:testDest2',
     'verifyDestResults'
   ]);
-  grunt.task.registerTask('testCoverage', ['connect:testUrls', 'mocha:testCoverage']);
+  grunt.task.registerTask('testCoverage', ['connect:testCoverage', 'mocha:testCoverage']);
   // WARNING: Running this test will cause grunt to fail after mocha:testBail
   grunt.task.registerTask('testBail', ['mocha:testBail', 'mocha:neverTest']);
   grunt.task.registerTask('test', [

--- a/README.md
+++ b/README.md
@@ -263,6 +263,36 @@ mocha: {
 },
 ```
 
+#### options.waitForCoverage
+Type: `Boolean`
+Default: `false`
+
+If your coverage data is being built in PhantomJS, you can pass it back to Node for your report to be written. Enabling this options waits for that coverage data to be passed.
+
+```js
+mocha: {
+  test: {
+    options: {
+      reporter: 'HTMLCov',
+      run: false,
+      waitForCoverage: true,
+      urls: [ 'http://localhost:8888/example/test/runner.html' ]
+    },
+    dest: './test/coverage.html'
+  }
+}
+```
+
+In your runner (or JS it includes), `alert` a JSON stringified array where 'coverage' is the first element and the coverage data is the second:
+
+```js
+mocha.run().on('end', function() {
+  coverage = window._$jscoverage; // your global variable may be different
+  // you may also need to manually prepare `coverage` for JSON.stringify
+  alert(JSON.stringify(['coverage', coverage]));
+});
+```
+
 ## Hacks
 
 The PhantomJS -> Grunt superdimensional conduit uses `alert`. If you have disabled or aliased alert in your app, this won't work. I have conveniently set a global `PHANTOMJS` on `window` so you can conditionally override alert in your app.

--- a/example/coffee/wombat.coffee
+++ b/example/coffee/wombat.coffee
@@ -1,0 +1,9 @@
+Wombat = (opts) ->
+  console.log "Log option works"
+  opts = opts or {}
+  @name = opts.name or "Wally"
+  @eat = (food) ->
+    throw Error("D:")  unless food
+    "nom nom"
+
+  this

--- a/example/js/wombat.coffee-coverage.js
+++ b/example/js/wombat.coffee-coverage.js
@@ -1,0 +1,43 @@
+if (typeof _$jscoverage === 'undefined') _$jscoverage = {};
+if ((typeof global !== 'undefined') && (typeof global._$jscoverage === 'undefined')) {
+    global._$jscoverage = _$jscoverage
+} else if ((typeof window !== 'undefined') && (typeof window._$jscoverage === 'undefined')) {
+    window._$jscoverage = _$jscoverage
+}
+if (! _$jscoverage["wombat.coffee"]) {
+    _$jscoverage["wombat.coffee"] = [];
+    _$jscoverage["wombat.coffee"][1] = 0;
+    _$jscoverage["wombat.coffee"][2] = 0;
+    _$jscoverage["wombat.coffee"][3] = 0;
+    _$jscoverage["wombat.coffee"][4] = 0;
+    _$jscoverage["wombat.coffee"][5] = 0;
+    _$jscoverage["wombat.coffee"][6] = 0;
+    _$jscoverage["wombat.coffee"][7] = 0;
+    _$jscoverage["wombat.coffee"][9] = 0;
+}
+
+_$jscoverage["wombat.coffee"].source = ["Wombat = (opts) ->", "  console.log \"Log option works\"", "  opts = opts or {}", "  @name = opts.name or \"Wally\"", "  @eat = (food) ->", "    throw Error(\"D:\")  unless food", "    \"nom nom\"", "", "  this", ""];
+
+var Wombat;
+
+_$jscoverage["wombat.coffee"][1]++;
+
+Wombat = function(opts) {
+  _$jscoverage["wombat.coffee"][2]++;
+  console.log("Log option works");
+  _$jscoverage["wombat.coffee"][3]++;
+  opts = opts || {};
+  _$jscoverage["wombat.coffee"][4]++;
+  this.name = opts.name || "Wally";
+  _$jscoverage["wombat.coffee"][5]++;
+  this.eat = function(food) {
+    _$jscoverage["wombat.coffee"][6]++;
+    if (!food) {
+      throw Error("D:");
+    }
+    _$jscoverage["wombat.coffee"][7]++;
+    return "nom nom";
+  };
+  _$jscoverage["wombat.coffee"][9]++;
+  return this;
+};

--- a/example/test/testCoverage.html
+++ b/example/test/testCoverage.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>Example Mocha Test with Coverage</title>
+    <link rel="stylesheet" href="css/mocha.css" type="text/css" charset="utf-8" />
+</head>
+<body>
+    <!-- Required for browser reporter -->
+    <div id="mocha"></div>
+
+    <!-- mocha -->
+    <script src="js/mocha.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript" charset="utf-8">
+        // This will be overridden by mocha-helper if you run with grunt
+        mocha.setup('bdd');
+    </script>
+
+    <!-- Include your assertion lib of choice -->
+    <script src="js/chai.js" type="text/javascript" charset="utf-8"></script>
+    <script type="text/javascript" charset="utf-8">
+        // Setup chai
+        var expect = chai.expect;
+    </script>
+
+    <!-- Include anything you want to test -->
+    <script src="../js/wombat.coffee-coverage.js" type="text/javascript" charset="utf-8"></script>
+
+    <!-- Spec files -->
+    <script src="spec/wombat.js" type="text/javascript" charset="utf-8"></script>
+
+    <!-- run mocha -->
+    <script type="text/javascript" charset="utf-8">
+        mocha.run().on('end', function() {
+            // prepare _$jscoverage to be properly JSONified
+            var coverage = {};
+
+            for (var filename in _$jscoverage) {
+              var data = _$jscoverage[filename];
+              var obj = {};
+              for (var line in data) {
+                var hit = data[line];
+                obj[line] = hit;
+              }
+              obj.source = data.source;
+              coverage[filename] = obj;
+            }
+
+            alert(JSON.stringify(['coverage', coverage]));
+        });
+    </script>
+</body>
+</html>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,516 @@
+{
+  "name": "grunt-mocha",
+  "version": "0.4.11",
+  "dependencies": {
+    "grunt-lib-phantomjs": {
+      "version": "0.4.0",
+      "from": "grunt-lib-phantomjs@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/grunt-lib-phantomjs/-/grunt-lib-phantomjs-0.4.0.tgz",
+      "dependencies": {
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "eventemitter2@>=0.4.9 <0.5.0",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+        },
+        "semver": {
+          "version": "1.0.14",
+          "from": "semver@>=1.0.14 <1.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-1.0.14.tgz"
+        },
+        "temporary": {
+          "version": "0.0.8",
+          "from": "temporary@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
+          "dependencies": {
+            "package": {
+              "version": "1.0.1",
+              "from": "package@>=1.0.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz"
+            }
+          }
+        },
+        "phantomjs": {
+          "version": "1.9.17",
+          "from": "phantomjs@>=1.9.0-1 <1.10.0",
+          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.17.tgz",
+          "dependencies": {
+            "adm-zip": {
+              "version": "0.4.4",
+              "from": "adm-zip@0.4.4",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+            },
+            "fs-extra": {
+              "version": "0.18.4",
+              "from": "fs-extra@>=0.18.0 <0.19.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.4.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.8",
+                  "from": "graceful-fs@>=3.0.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                },
+                "jsonfile": {
+                  "version": "2.2.1",
+                  "from": "jsonfile@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.1.tgz"
+                },
+                "rimraf": {
+                  "version": "2.4.1",
+                  "from": "rimraf@>=2.2.8 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.4.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "2.0.8",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "kew": {
+              "version": "0.4.0",
+              "from": "kew@0.4.0",
+              "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
+            },
+            "npmconf": {
+              "version": "2.1.1",
+              "from": "npmconf@2.1.1",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.9",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "from": "ini@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.3",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.3",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.0",
+                      "from": "os-homedir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            },
+            "progress": {
+              "version": "1.1.8",
+              "from": "progress@1.1.8",
+              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+            },
+            "request": {
+              "version": "2.42.0",
+              "from": "request@2.42.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "qs": {
+                  "version": "1.2.2",
+                  "from": "qs@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.1",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.0.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@>=1.2.11 <1.3.0"
+                    },
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.4.0",
+                  "from": "oauth-sign@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.3.1",
+              "from": "request-progress@0.3.1",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "2.3.0",
+      "from": "lodash@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.3.0.tgz"
+    },
+    "mocha": {
+      "version": "1.18.2",
+      "from": "mocha@>=1.18.0 <1.19.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.18.2.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.0.0",
+          "from": "commander@2.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+        },
+        "growl": {
+          "version": "1.7.0",
+          "from": "growl@>=1.7.0 <1.8.0",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "from": "jade@0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "from": "commander@0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.0.7",
+          "from": "diff@1.0.7",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@*",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "from": "glob@3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.11 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.5",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I came up with a way to generate HTML code coverage reports from a coverage object in PhantomJS. I'll admit it feels like a hack, but it works so I thought I'd present it for feedback and consideration since I know it's been a long time ask (#44).

Background: We write CoffeeScript and use `grunt-mocha` to run our client tests. We use [coffee-coverage](https://github.com/benbria/coffee-coverage) to generate [JSCoverage](http://siliconforks.com/jscoverage/) style instrumentation which Mocha can use to produce really nice HTML coverage reports.

Problem: The global coverage object is in PhantomJS and not available until Mocha's run has ended.

Solution: 

1. Don't end the PhantomJS process when Mocha initially ends
2. Alert the coverage data (properly JSONified) and listen to the event to assign the global in Node. This global is [what Mocha's JSONCov reporter uses](https://github.com/visionmedia/mocha/blob/master/lib/reporters/json-cov.js#L45) (which is [what HTMLCov](https://github.com/visionmedia/mocha/blob/master/lib/reporters/html-cov.js#L29)) uses. 
3. Fire another `mocha.end` event to actually end the process which will emit to the reporter which can now write it's HTML file

Potential Issues:

I know this reintroduces hijacking `process.stdout` which could cause [backwards compatibility issues](https://github.com/kmiyashiro/grunt-mocha/commit/91d22d9704451ba0280ee17a71827b82b523bd2a), but, [HTMLCov, like XUnit, now uses it](https://github.com/visionmedia/mocha/blob/master/lib/reporters/html-cov.js#L32)

I did my best to provide tests. Happy to add more. Would appreciate any feedback!