### PR TITLE
Bump grunt-lib-phantomjs to latest master

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "node": "*"
   },
   "scripts": {
-    "test": "./node_modules/.bin/grunt test"
+    "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "^0.7.1",
-    "mocha": "^2.3.4",
+    "grunt-lib-phantomjs": "gruntjs/grunt-lib-phantomjs#776bc346a8b7e151fe55c7f6dcb5563c0272e51b",
+    "mocha": "^2.4.5",
     "lodash": "^3.9.0"
   },
   "peerDependencies": {

--- a/phantomjs/main.js
+++ b/phantomjs/main.js
@@ -14,13 +14,14 @@
 
 var fs = require('fs');
 var _ = require('lodash');
+var system = require('system');
 
 // The temporary file used for communications.
-var tmpfile = phantom.args[0];
+var tmpfile = system.args[1];
 // The page .html file to load.
-var url = phantom.args[1];
+var url = system.args[2];
 // Extra, optionally overridable stuff.
-var options = JSON.parse(phantom.args[2] || {});
+var options = JSON.parse(system.args[3] || {});
 
 // Keep track of the last time a client message was sent.
 var last = new Date();


### PR DESCRIPTION
Fixes #157.

With this patch, the project uses Phantom2 to run tests.

Uses the latest commit from `grunt-lib-phantomjs` instead of the latest published `1.0.1` version since it has a bug on Windows, causing random `EBUSY` errors which is fixed on master.