### PR TITLE
Update peerDependency to allow Grunt 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^3.9.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4"
+    "grunt": ">=0.4.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
All Grunt plugins are strongly recommended to update their peerDependencies to allow Grunt 1.0.0 as of an official announcement of its 1.0.0 release. This change make it.
http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies