### PR TITLE
Use the published version of Phantom library

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-phantomjs": "gruntjs/grunt-lib-phantomjs#776bc346a8b7e151fe55c7f6dcb5563c0272e51b",
+    "grunt-lib-phantomjs": "^1.0.2",
     "mocha": "^2.4.5",
     "lodash": "^3.9.0"
   },


### PR DESCRIPTION
The custom GitHub/sha link is not necessary anymore since they've released 1.0.2 which includes the fix we needed.